### PR TITLE
Pr scroll skip missing targets

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -2,7 +2,14 @@
   "$schema": "node_modules/oxfmt/configuration_schema.json",
   "semi": false,
   "singleQuote": true,
-  "ignorePatterns": ["node_modules", "dist", "coverage"],
+  "ignorePatterns": [
+    "node_modules",
+    "dist",
+    "coverage",
+    "**/*.{yml,yaml}",
+    "assets/yiyan.json",
+    "**/*.md"
+  ],
   "overrides": [
     {
       "files": ["*.json", "*.jsonc"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
   await page.waitForTimeout(10000)
 
   for (const targetName of targetNames) {
-    cconst name = String(targetName).trim()
+    const name = String(targetName).trim()
     if (!name) continue
 
 console.log(`开始查找会话：${name}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,10 +35,45 @@ async function main(): Promise<void> {
   await page.waitForTimeout(10000)
 
   for (const targetName of targetNames) {
-    const target = page.locator('[data-e2e="conversation-item"]').filter({
-      has: page.getByText(targetName, { exact: true }),
+    cconst name = String(targetName).trim()
+    if (!name) continue
+
+console.log(`开始查找会话：${name}`)
+
+// 鼠标移到左侧聊天列表区域，先滚回顶部
+await page.mouse.move(250, 450)
+for (let i = 0; i < 12; i++) {
+  await page.mouse.wheel(0, -1200)
+  await page.waitForTimeout(100)
+}
+
+let targetClicked = false
+
+// 从上往下滚动查找会话
+for (let i = 0; i < 45; i++) {
+  const target = page
+    .locator('[data-e2e="conversation-item"]')
+    .filter({
+      has: page.getByText(name, { exact: true }),
     })
-    await target.click()
+    .first()
+
+  if (await target.isVisible({ timeout: 800 }).catch(() => false)) {
+    await target.click({ timeout: 5000 })
+    targetClicked = true
+    console.log(`已找到会话：${name}`)
+    break
+  }
+
+  await page.mouse.move(250, 450)
+  await page.mouse.wheel(0, 900)
+  await page.waitForTimeout(600)
+}
+
+if (!targetClicked) {
+  console.log(`找不到会话，已跳过：${name}`)
+  continue
+}
 
     const editorInput = page.locator('.messageEditorimChatEditorContainer [data-slate-editor="true"][contenteditable="true"]')
     await editorInput.waitFor({ state: 'visible' })

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,52 +34,44 @@ async function main(): Promise<void> {
 
   await page.waitForTimeout(10000)
 
+  const searchInput = page.locator('input.semi-input[placeholder="搜索"]').first()
+  await searchInput.waitFor({ state: 'visible', timeout: 10000 })
+
   for (const targetName of targetNames) {
     const name = String(targetName).trim()
     if (!name) continue
 
-console.log(`开始查找会话：${name}`)
+    console.log(`开始搜索会话：${name}`)
+    await searchInput.fill('')
+    await searchInput.fill(name)
+    await page.waitForTimeout(1000)
 
-// 鼠标移到左侧聊天列表区域，先滚回顶部
-await page.mouse.move(250, 450)
-for (let i = 0; i < 12; i++) {
-  await page.mouse.wheel(0, -1200)
-  await page.waitForTimeout(100)
-}
+    const searchResult = page
+      .locator('.SearchPanelitembox')
+      .filter({
+        has: page.getByText(name, { exact: true }),
+      })
+      .first()
 
-let targetClicked = false
+    if (!(await searchResult.isVisible({ timeout: 5000 }).catch(() => false))) {
+      console.log(`找不到搜索结果，已跳过：${name}`)
+      continue
+    }
 
-// 从上往下滚动查找会话
-for (let i = 0; i < 45; i++) {
-  const target = page
-    .locator('[data-e2e="conversation-item"]')
-    .filter({
-      has: page.getByText(name, { exact: true }),
-    })
-    .first()
+    await searchResult.getByText('发私信', { exact: true }).click({ timeout: 5000 })
+    console.log(`已打开私信：${name}`)
 
-  if (await target.isVisible({ timeout: 800 }).catch(() => false)) {
-    await target.click({ timeout: 5000 })
-    targetClicked = true
-    console.log(`已找到会话：${name}`)
-    break
-  }
-
-  await page.mouse.move(250, 450)
-  await page.mouse.wheel(0, 900)
-  await page.waitForTimeout(600)
-}
-
-if (!targetClicked) {
-  console.log(`找不到会话，已跳过：${name}`)
-  continue
-}
-
-    const editorInput = page.locator('.messageEditorimChatEditorContainer [data-slate-editor="true"][contenteditable="true"]')
-    await editorInput.waitFor({ state: 'visible' })
+    const editorInput = page
+      .locator(
+        '.messageEditorimChatEditorContainer [data-slate-editor="true"][contenteditable="true"]',
+      )
+      .first()
+    await editorInput.waitFor({ state: 'visible', timeout: 10000 })
     await editorInput.click()
     await page.keyboard.insertText(pickRandomYiyan(yiyans).hitokoto)
     await page.keyboard.press('Enter')
+    console.log(`已发送消息：${name}`)
+    await page.waitForTimeout(1000)
   }
 
   await page.waitForTimeout(5000)
@@ -178,12 +170,18 @@ function resolveDouyinTargetNames(): string[] {
   const targetNamesText = process.env[DOUYIN_TARGET_NAMES_KEY]?.trim()
 
   if (!targetNamesText) {
-    throw new Error(`请设置环境变量 ${DOUYIN_TARGET_NAMES_KEY}，或在 .env 中配置 ${DOUYIN_TARGET_NAMES_KEY}`)
+    throw new Error(
+      `请设置环境变量 ${DOUYIN_TARGET_NAMES_KEY}，或在 .env 中配置 ${DOUYIN_TARGET_NAMES_KEY}`,
+    )
   }
 
   const targetNames = JSON.parse(targetNamesText) as string[]
 
-  if (!Array.isArray(targetNames) || targetNames.length === 0 || targetNames.some((targetName) => typeof targetName !== 'string' || !targetName.trim())) {
+  if (
+    !Array.isArray(targetNames) ||
+    targetNames.length === 0 ||
+    targetNames.some((targetName) => typeof targetName !== 'string' || !targetName.trim())
+  ) {
     throw new Error(`${DOUYIN_TARGET_NAMES_KEY} 必须是非空字符串数组 JSON`)
   }
 


### PR DESCRIPTION
之前如果某个目标不在当前加载出来的聊天列表里，就会直接 Timeout，导致整个任务失败。

现在改成：
- 目标名前后空格会先处理掉；
- 查找时会滚动左侧聊天列表；
- 找不到某个目标就跳过，继续处理后面的；
- 日志里会显示哪些找到了、哪些没找到。

这样多目标续火的时候稳定一点，不会因为一个人没找到就全挂。
hmm您看一下