### PR TITLE
feat: 目标会话未找到时报错告警，并建议使用备注名

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ AUTO_CLOSE=true
 YIYAN_INCLUDE_SOURCE=true
 
 # 要发送消息的抖音会话名称，必须是一整行 JSON 字符串数组。
+# 建议先在抖音中给好友设置备注名，这里填备注名。备注由你自己设置，好友改昵称也不会影响续火。
 DOUYIN_TARGET_NAMES='["暮邵落白"]'
 
 # 抖音 Cookie，使用 https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm 浏览器插件，进入 https://www.douyin.com/chat ，并点击 export -> json 获取

--- a/README.md
+++ b/README.md
@@ -98,13 +98,15 @@ Settings -> Secrets and variables -> Actions -> New repository secret
 | Secret | 必填 | 说明 |
 |:---|:---:|:---|
 | `DOUYIN_COOKIE` | ✅ | 抖音 Cookie JSON 字符串数组 （上面用浏览器插件获取的那个） |
-| `DOUYIN_TARGET_NAMES` | ✅ | 需要续火的朋友的用户名称， JSON 字符串数组，例如 ["暮邵落白"] （不会写 JSON 可以问 AI） |
+| `DOUYIN_TARGET_NAMES` | ✅ | 需要续火的朋友的用户名称， JSON 字符串数组，例如 ["暮邵落白"] （不会写 JSON 可以问 AI）。建议在抖音中给好友设置备注名并填备注名，好友改昵称也不会中断续火 |
 | `YIYAN_INCLUDE_SOURCE` | ❌ | 是否携带一言出处，默认开启；设置为 `false` 时只发送正文 |
 | `MAIL_ADDRESS` | ❌ | 任务失败提醒的收件邮箱，同时作为邮件发件人地址 |
 | `MAIL_USERNAME` | ❌ | QQ 邮箱 SMTP 登录账号，通常与 `MAIL_ADDRESS` 相同 |
 | `MAIL_PASSWORD` | ❌ | QQ 邮箱 SMTP 授权码 |
 
 配置 `MAIL_ADDRESS`、`MAIL_USERNAME` 和 `MAIL_PASSWORD` 后，续火失败会向 `MAIL_ADDRESS` 发送提醒邮件，并附带失败图片。
+
+如果配置的会话有一个没找到（通常是好友改了昵称），脚本会先把其余好友的消息发完，再以失败状态结束并告警，因此不会出现「任务显示成功但火花已经断了」的情况。
 
 #### 3️⃣ 手动运行一次
 
@@ -150,6 +152,12 @@ cp .env.example .env
 ```dotenv
 DOUYIN_TARGET_NAMES='["暮邵落白"]'
 ```
+
+> 💡 **建议填备注名而不是昵称**
+>
+> 脚本靠聊天页搜索框定位好友，好友一旦改昵称就会搜不到，火花随之中断。
+> 在抖音中给好友设置备注后，搜索框同样能按备注名搜到人，而备注是你自己设置的，
+> 好友再怎么改昵称都不受影响。设置方式：好友主页 → 右上角 `...` → 设置备注。
 
 `DOUYIN_COOKIE` 使用准备工作中导出的 Cookie JSON 数组：
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,9 @@ async function main(): Promise<void> {
     const searchInput = page.locator('input.semi-input[placeholder="搜索"]').first()
     await searchInput.waitFor({ state: 'visible', timeout: 10000 })
 
+    // 记录未命中的会话，等其余好友都发完再统一报错，避免一个人改名连累当天所有人。
+    const missingNames: string[] = []
+
     for (const targetName of targetNames) {
       const name = String(targetName).trim()
       if (!name) continue
@@ -60,6 +63,7 @@ async function main(): Promise<void> {
 
       if (!(await searchResult.isVisible({ timeout: 5000 }).catch(() => false))) {
         console.log(`找不到搜索结果，已跳过：${name}`)
+        missingNames.push(name)
         continue
       }
 
@@ -91,6 +95,15 @@ async function main(): Promise<void> {
 
       await readline.question('Chrome 已打开抖音聊天页，按回车键关闭浏览器...')
       readline.close()
+    }
+
+    // 静默跳过会让任务以成功状态结束，失败告警便永远不会触发，因此这里必须抛错。
+    if (missingNames.length > 0) {
+      throw new Error(
+        `以下会话未找到，火花可能已经中断：${missingNames.join('、')}。` +
+          `好友改昵称是最常见的原因，建议在抖音中为好友设置备注名，` +
+          `并把备注名填入 ${DOUYIN_TARGET_NAMES_KEY}，这样好友再改昵称也不会影响续火。`,
+      )
     }
   } catch (error) {
     await captureFailureScreenshot(page)


### PR DESCRIPTION
好友改昵称后，脚本在搜索面板中定位不到该会话，此前只打印一行日志便
continue，进程仍以 0 退出。在 GitHub Actions 中这会被判定为成功，
workflow 里 `if: failure()` 的邮件告警不会触发，用户直到火花中断很久
之后才可能发现。

改为收集所有未命中的会话名，待其余好友都发送完成后再抛错，让失败截图
和邮件告警正常工作。先发完再报错是为了避免一个好友改名连累当天其他人
的火花。

错误信息中提示改用备注名，README 与 .env.example 同步补充说明：备注由
用户自己设置，好友再改昵称也不会影响续火。