### PR TITLE
feat: 支持多账号抖音续火

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,52 +16,9 @@ YIYAN_INCLUDE_SOURCE=true
 # 自定义火花消息模板，可选。配置说明见 README。
 # SPARK_MESSAGE_TEMPLATE={{friend}}，今天的火花到账啦🔥\n{{yiyan}}\n——「{{from}}」\n{{date}} {{weekday}}
 
-# 多账号配置。本地 .env 支持下面这种多行 JSON 写法。
-# 每个账号都完整写出 name、cookie、targetNames、messageTemplate 四个可配置字段。
-# cookie 请整体替换为对应账号从 Cookie-Editor 导出的完整数组，不要只替换示例中的 value。
-DOUYIN_ACCOUNTS='[
-  {
-    "name": "账号1",
-    "cookie": [
-      {
-        "domain": ".douyin.com",
-        "expirationDate": 1800175766.87008,
-        "hostOnly": false,
-        "httpOnly": false,
-        "name": "UIFID",
-        "path": "/",
-        "sameSite": "no_restriction",
-        "secure": true,
-        "session": false,
-        "storeId": null,
-        "value": "替换成账号1的真实 Cookie 值"
-      }
-    ],
-    "targetNames": ["好友A", "好友B"],
-    "messageTemplate": "{{friend}}，今天也来续火啦\\n{{yiyan}}\\n——「{{from}}」"
-  },
-  {
-    "name": "账号2",
-    "cookie": [
-      {
-        "domain": ".douyin.com",
-        "expirationDate": 1800175766.87008,
-        "hostOnly": false,
-        "httpOnly": false,
-        "name": "UIFID",
-        "path": "/",
-        "sameSite": "no_restriction",
-        "secure": true,
-        "session": false,
-        "storeId": null,
-        "value": "替换成账号2的真实 Cookie 值"
-      }
-    ],
-    "targetNames": ["好友C"],
-    "messageTemplate": "{{friend}}，{{account}} 今天来续火啦\\n{{date}} {{weekday}}"
-  }
-]'
+# 单账号配置。
+DOUYIN_TARGET_NAMES='["暮邵落白"]'
+DOUYIN_COOKIE='[{"domain":".douyin.com","expirationDate":1800175766.87008,"hostOnly":false,"httpOnly":false,"name":"UIFID","path":"/","sameSite":"no_restriction","secure":true,"session":false,"storeId":null,"value":"替换成真实 Cookie 值"}]'
 
-# 旧版单账号变量仍然兼容。配置 DOUYIN_ACCOUNTS 后会忽略下面两个变量。
-# DOUYIN_TARGET_NAMES='["暮邵落白"]'
-# DOUYIN_COOKIE='[{"domain":".douyin.com","expirationDate":1800175766.87008,"hostOnly":false,"httpOnly":false,"name":"UIFID","path":"/","sameSite":"no_restriction","secure":true,"session":false,"storeId":null,"value":"替换成真实 Cookie 值"}]'
+# 多账号配置见 README。配置后会无视上面的单账号配置。
+# DOUYIN_ACCOUNTS=

--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,52 @@ YIYAN_INCLUDE_SOURCE=true
 # 自定义火花消息模板，可选。配置说明见 README。
 # SPARK_MESSAGE_TEMPLATE={{friend}}，今天的火花到账啦🔥\n{{yiyan}}\n——「{{from}}」\n{{date}} {{weekday}}
 
-# 要发送消息的抖音会话名称，必须是一整行 JSON 字符串数组。
-# 建议先在抖音中给好友设置备注名，这里填备注名。备注由你自己设置，好友改昵称也不会影响续火。
-DOUYIN_TARGET_NAMES='["暮邵落白"]'
+# 多账号配置。本地 .env 支持下面这种多行 JSON 写法。
+# 每个账号都完整写出 name、cookie、targetNames、messageTemplate 四个可配置字段。
+# cookie 请整体替换为对应账号从 Cookie-Editor 导出的完整数组，不要只替换示例中的 value。
+DOUYIN_ACCOUNTS='[
+  {
+    "name": "账号1",
+    "cookie": [
+      {
+        "domain": ".douyin.com",
+        "expirationDate": 1800175766.87008,
+        "hostOnly": false,
+        "httpOnly": false,
+        "name": "UIFID",
+        "path": "/",
+        "sameSite": "no_restriction",
+        "secure": true,
+        "session": false,
+        "storeId": null,
+        "value": "替换成账号1的真实 Cookie 值"
+      }
+    ],
+    "targetNames": ["好友A", "好友B"],
+    "messageTemplate": "{{friend}}，今天也来续火啦\\n{{yiyan}}\\n——「{{from}}」"
+  },
+  {
+    "name": "账号2",
+    "cookie": [
+      {
+        "domain": ".douyin.com",
+        "expirationDate": 1800175766.87008,
+        "hostOnly": false,
+        "httpOnly": false,
+        "name": "UIFID",
+        "path": "/",
+        "sameSite": "no_restriction",
+        "secure": true,
+        "session": false,
+        "storeId": null,
+        "value": "替换成账号2的真实 Cookie 值"
+      }
+    ],
+    "targetNames": ["好友C"],
+    "messageTemplate": "{{friend}}，{{account}} 今天来续火啦\\n{{date}} {{weekday}}"
+  }
+]'
 
-# 抖音 Cookie，使用 https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm 浏览器插件，进入 https://www.douyin.com/chat ，并点击 export -> json 获取
-DOUYIN_COOKIE='[{"domain":".douyin.com","expirationDate":1800175766.87008,"hostOnly":false,"httpOnly":false,"name":"UIFID","path":"/","sameSite":"no_restriction","secure":true,"session":false,"storeId":null,"value":"替换成真实 Cookie 值"}]'
+# 旧版单账号变量仍然兼容。配置 DOUYIN_ACCOUNTS 后会忽略下面两个变量。
+# DOUYIN_TARGET_NAMES='["暮邵落白"]'
+# DOUYIN_COOKIE='[{"domain":".douyin.com","expirationDate":1800175766.87008,"hostOnly":false,"httpOnly":false,"name":"UIFID","path":"/","sameSite":"no_restriction","secure":true,"session":false,"storeId":null,"value":"替换成真实 Cookie 值"}]'

--- a/.github/workflows/renew-fire.yml
+++ b/.github/workflows/renew-fire.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: mcr.microsoft.com/playwright:v1.61.0-jammy
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: 克隆当前仓库 (Clone current repo)
@@ -30,6 +30,7 @@ jobs:
 
       - name: 续一次火 (Run spark job)
         env:
+          DOUYIN_ACCOUNTS: ${{ secrets.DOUYIN_ACCOUNTS }}
           DOUYIN_COOKIE: ${{ secrets.DOUYIN_COOKIE }}
           DOUYIN_TARGET_NAMES: ${{ secrets.DOUYIN_TARGET_NAMES }}
           YIYAN_INCLUDE_SOURCE: ${{ secrets.YIYAN_INCLUDE_SOURCE }}
@@ -48,7 +49,7 @@ jobs:
           subject: 抖音续火任务失败
           to: ${{ secrets.MAIL_ADDRESS }}
           from: ${{ secrets.MAIL_ADDRESS }}
-          attachments: artifacts/failure-screenshot.png
+          attachments: artifacts/*.png
           body: |
             抖音续火任务执行失败
             仓库：${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@
 
 ## ✨ 项目简介
 
-本项目是一个基于 **Playwright + TypeScript** 的抖音聊天自动化脚本。它会依次使用你配置的多个抖音账号打开聊天页，按各账号的会话名称定位聊天对象，并从 `assets/yiyan.json` 中随机挑选一言发送出去。
-
-适合放到 GitHub Actions 中定时运行，也可以在本地用 `pnpm dev` 手动执行。
+本项目是一个基于 **Playwright + TypeScript** 的抖音自动续火脚本。它会携带你配置的抖音 Cookie 打开聊天页，按配置的会话名称依次定位聊天对象，并从 `assets/yiyan.json` 中随机挑选一言发送出去。支持 Github Actions 运行和本地运行两种方式。
 
 ## 🚀 功能特性
 
-- 🎭 **多账号 Cookie 登录** - 通过 `DOUYIN_ACCOUNTS` 配置多个抖音登录态，每个账号使用独立浏览器上下文
-- 🎯 **账号独立会话** - 每个账号分别配置聊天对象，单个账号失败不会阻止其他账号继续执行
+- 🎭 **Cookie 登录** - 通过 `DOUYIN_COOKIE` 注入抖音登录态，无需在脚本中输入账号密码
+- 🎯 **多会话发送** - 通过 `DOUYIN_TARGET_NAMES` 配置多个聊天对象
+- 👥 **多账号续火** - 可通过 `DOUYIN_ACCOUNTS` 为多个账号分别配置 Cookie、聊天对象和消息模板
 - 💬 **随机一言** - 每次从 `assets/yiyan.json` 随机挑选一条 `hitokoto`，默认以 `——「出处」` 的格式附上来源
 - 🤖 **定时续火** - 通过 Github Action 每天 0 点自动续火（但是 Github 定时任务要排队，可能会延迟几个小时）
 
@@ -64,7 +63,7 @@
 ]
 ```
 
-后面配置 `DOUYIN_ACCOUNTS` 时，把每个账号导出的完整 Cookie 数组放入对应账号的 `cookie` 字段。
+后面配置 `DOUYIN_COOKIE` 时，需要把整个 JSON 数组作为 Secret 填进去。
 
 ## 运行方式
 ### ⚙️ GitHub Actions
@@ -97,72 +96,16 @@ Settings -> Secrets and variables -> Actions -> New repository secret
 
 | Secret | 必填 | 说明 |
 |:---|:---:|:---|
-| `DOUYIN_ACCOUNTS` | ✅ | 抖音账号 JSON 数组，每个账号包含 `name`、`cookie`、`targetNames`、`messageTemplate` |
-| `YIYAN_INCLUDE_SOURCE` | ❌ | 是否携带一言出处，默认开启；设置为 `false` 时只发送正文 |
+| `DOUYIN_COOKIE` | ✅ | Cookie-Editor 导出的完整 Cookie JSON 数组 |
+| `DOUYIN_TARGET_NAMES` | ✅ | 需要续火的好友名称 JSON 数组，例如 `["暮邵落白"]`，建议填写抖音备注名 |
+| `DOUYIN_ACCOUNTS` | ❌ | 多账号配置，配置后会无视单账号配置，详情见下方「👥 多账号配置」 |
+| `YIYAN_INCLUDE_SOURCE` | ❌ | 是否携带一言出处，默认开启；设置为 `false` 时只发送一言正文 |
 | `SPARK_MESSAGE_TEMPLATE` | ❌ | 自定义火花消息模板，见下方「✉️ 自定义消息模板」 |
 | `MAIL_ADDRESS` | ❌ | 任务失败提醒的收件邮箱，同时作为邮件发件人地址 |
 | `MAIL_USERNAME` | ❌ | QQ 邮箱 SMTP 登录账号，通常与 `MAIL_ADDRESS` 相同 |
 | `MAIL_PASSWORD` | ❌ | QQ 邮箱 SMTP 授权码 |
 
 配置 `MAIL_ADDRESS`、`MAIL_USERNAME` 和 `MAIL_PASSWORD` 后，续火失败会向 `MAIL_ADDRESS` 发送提醒邮件，并附带失败图片。
-
-`DOUYIN_ACCOUNTS` 可以直接粘贴下面这种多行 JSON。每个账号的 `cookie` 都要替换成 Cookie-Editor 导出的完整数组，不能只替换示例中的一个 Cookie。
-
-```json
-[
-  {
-    "name": "账号1",
-    "cookie": [
-      {
-        "domain": ".douyin.com",
-        "expirationDate": 1800175766.87008,
-        "hostOnly": false,
-        "httpOnly": false,
-        "name": "UIFID",
-        "path": "/",
-        "sameSite": "no_restriction",
-        "secure": true,
-        "session": false,
-        "storeId": null,
-        "value": "账号1的真实 Cookie 值"
-      }
-    ],
-    "targetNames": ["好友A", "好友B"],
-    "messageTemplate": "{{friend}}，今天也来续火啦\\n{{yiyan}}\\n——「{{from}}」"
-  },
-  {
-    "name": "账号2",
-    "cookie": [
-      {
-        "domain": ".douyin.com",
-        "expirationDate": 1800175766.87008,
-        "hostOnly": false,
-        "httpOnly": false,
-        "name": "UIFID",
-        "path": "/",
-        "sameSite": "no_restriction",
-        "secure": true,
-        "session": false,
-        "storeId": null,
-        "value": "账号2的真实 Cookie 值"
-      }
-    ],
-    "targetNames": ["好友C"],
-    "messageTemplate": "{{friend}}，{{account}} 今天来续火啦\\n{{date}} {{weekday}}"
-  }
-]
-```
-
-账号级 `messageTemplate` 未配置时，会使用全局 `SPARK_MESSAGE_TEMPLATE`；全局模板也未配置时使用默认一言格式。
-
-每个账号对象支持的字段：
-
-| 字段 | 必填 | 说明 |
-|:---|:---:|:---|
-| `name` | ✅ | 账号标识，用于日志、错误提示、失败截图和 `{{account}}` 占位符；不同账号不能重名 |
-| `cookie` | ✅ | Cookie-Editor 为这个账号导出的完整 JSON 数组 |
-| `targetNames` | ✅ | 这个账号需要发送消息的好友名称数组，建议使用抖音备注名 |
-| `messageTemplate` | ❌ | 账号独立模板；JSON 字符串中的换行写成 `\n`，未配置时继承全局模板 |
 
 #### 3️⃣ 手动运行一次
 
@@ -200,17 +143,29 @@ cp .env.example .env
 
 | 变量 | 必填 | 默认值 | 说明 |
 |:---|:---:|:---:|:---|
-| `DOUYIN_ACCOUNTS` | ✅ | - | 抖音账号 JSON 数组，结构与上方 GitHub Secret 相同 |
-| `YIYAN_INCLUDE_SOURCE` | ❌ | `true` | 是否携带一言出处，设置为 `false` 时只发送正文 |
+| `DOUYIN_COOKIE` | ✅ | - | Cookie-Editor 导出的完整 Cookie JSON 数组 |
+| `DOUYIN_TARGET_NAMES` | ✅ | - | 要发送消息的好友名称 JSON 数组 |
+| `DOUYIN_ACCOUNTS` | ❌ | - | 多账号配置，配置后会无视单账号配置，详情见下方「👥 多账号配置」 |
+| `YIYAN_INCLUDE_SOURCE` | ❌ | `true` | 是否携带一言出处，设置为 `false` 时只发送一言正文 |
 | `SPARK_MESSAGE_TEMPLATE` | ❌ | - | 自定义火花消息模板，见下方「自定义消息模板」 |
 | `PLAYWRIGHT_BROWSER_PATH` | ❌ | - | 本机 Chrome / Chromium / Edge 可执行文件路径，不填则使用 Playwright 默认浏览器 |
 | `PLAYWRIGHT_HEADLESS` | ❌ | `true` | 是否使用无头模式 |
 | `AUTO_CLOSE` | ❌ | `true` | 发送完成后是否自动关闭浏览器 |
 
-本地 `.env` 示例：
+#### 3️⃣ 启动项目
 
-```dotenv
-DOUYIN_ACCOUNTS='[
+```bash
+pnpm dev
+```
+
+脚本会打开 `https://www.douyin.com/chat`，依次定位配置中的好友并发送随机一言。
+
+## 👥 多账号配置
+
+需要为多个抖音账号续火时，将下面的 JSON 保存为 GitHub Secret 或本地环境变量 `DOUYIN_ACCOUNTS`。每个账号的 `cookie` 都要替换成 Cookie-Editor 导出的完整数组。
+
+```json
+[
   {
     "name": "账号1",
     "cookie": [
@@ -225,30 +180,44 @@ DOUYIN_ACCOUNTS='[
         "secure": true,
         "session": false,
         "storeId": null,
-        "value": "替换成真实 Cookie 值"
+        "value": "账号1的真实 Cookie 值"
       }
     ],
-    "targetNames": ["好友A", "好友B"],
-    "messageTemplate": "{{friend}}，今天也来续火啦\\n{{yiyan}}"
+    "targetNames": ["好友A", "好友B"]
+  },
+  {
+    "name": "账号2",
+    "cookie": [
+      {
+        "domain": ".douyin.com",
+        "expirationDate": 1800175766.87008,
+        "hostOnly": false,
+        "httpOnly": false,
+        "name": "UIFID",
+        "path": "/",
+        "sameSite": "no_restriction",
+        "secure": true,
+        "session": false,
+        "storeId": null,
+        "value": "账号2的真实 Cookie 值"
+      }
+    ],
+    "targetNames": ["好友C"],
+    "messageTemplate": "{{friend}}，{{account}} 今天来续火啦\\n{{date}} {{weekday}}"
   }
-]'
+]
 ```
 
-> 💡 **建议填备注名而不是昵称**
->
-> 脚本靠聊天页搜索框定位好友，好友一旦改昵称就会搜不到，火花随之中断。
-> 在抖音中给好友设置备注后，搜索框同样能按备注名搜到人，而备注是你自己设置的，
-> 好友再怎么改昵称都不受影响。设置方式：好友主页 → 右上角 `...` → 设置备注。
+每个账号对象支持的字段：
 
-旧版 `DOUYIN_COOKIE` 和 `DOUYIN_TARGET_NAMES` 仍然兼容。配置 `DOUYIN_ACCOUNTS` 后，新配置优先，旧变量会被忽略。
+| 字段 | 必填 | 说明 |
+|:---|:---:|:---|
+| `name` | ✅ | 账号标识，用于日志、错误提示、失败截图和 `{{account}}` 占位符；不同账号不能重名 |
+| `cookie` | ✅ | Cookie-Editor 为这个账号导出的完整 JSON 数组 |
+| `targetNames` | ✅ | 这个账号需要发送消息的好友名称数组，建议使用抖音备注名 |
+| `messageTemplate` | ❌ | 账号独立模板；JSON 字符串中的换行写成 `\n`，未配置时继承全局模板 |
 
-#### 3️⃣ 启动项目
-
-```bash
-pnpm dev
-```
-
-脚本会为每个账号创建独立浏览器上下文，依次打开 `https://www.douyin.com/chat`、发送消息并关闭上下文。某个账号失败后会保存账号专属截图并继续执行其余账号，全部执行结束后统一报告失败。
+配置 `DOUYIN_ACCOUNTS` 后会优先使用多账号配置。脚本会依次运行各账号，单个账号失败后继续执行其余账号，最后统一报告失败。
 
 ## ✉️ 自定义消息模板
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@
 
 ## ✨ 项目简介
 
-本项目是一个基于 **Playwright + TypeScript** 的抖音聊天自动化脚本。它会携带你配置的抖音 Cookie 打开聊天页，按配置的会话名称依次定位聊天对象，并从 `assets/yiyan.json` 中随机挑选一言发送出去。
+本项目是一个基于 **Playwright + TypeScript** 的抖音聊天自动化脚本。它会依次使用你配置的多个抖音账号打开聊天页，按各账号的会话名称定位聊天对象，并从 `assets/yiyan.json` 中随机挑选一言发送出去。
 
 适合放到 GitHub Actions 中定时运行，也可以在本地用 `pnpm dev` 手动执行。
 
 ## 🚀 功能特性
 
-- 🎭 **Cookie 登录** - 通过 `DOUYIN_COOKIE` 注入抖音登录态，无需脚本内输入账号密码
-- 🎯 **多会话发送** - 通过 `DOUYIN_TARGET_NAMES` 配置多个聊天对象
+- 🎭 **多账号 Cookie 登录** - 通过 `DOUYIN_ACCOUNTS` 配置多个抖音登录态，每个账号使用独立浏览器上下文
+- 🎯 **账号独立会话** - 每个账号分别配置聊天对象，单个账号失败不会阻止其他账号继续执行
 - 💬 **随机一言** - 每次从 `assets/yiyan.json` 随机挑选一条 `hitokoto`，默认以 `——「出处」` 的格式附上来源
 - 🤖 **定时续火** - 通过 Github Action 每天 0 点自动续火（但是 Github 定时任务要排队，可能会延迟几个小时）
 
@@ -64,7 +64,7 @@
 ]
 ```
 
-后面配置 `DOUYIN_COOKIE` 时，需要把整个 JSON 数组作为一行字符串填进去。
+后面配置 `DOUYIN_ACCOUNTS` 时，把每个账号导出的完整 Cookie 数组放入对应账号的 `cookie` 字段。
 
 ## 运行方式
 ### ⚙️ GitHub Actions
@@ -97,8 +97,7 @@ Settings -> Secrets and variables -> Actions -> New repository secret
 
 | Secret | 必填 | 说明 |
 |:---|:---:|:---|
-| `DOUYIN_COOKIE` | ✅ | 抖音 Cookie JSON 字符串数组 （上面用浏览器插件获取的那个） |
-| `DOUYIN_TARGET_NAMES` | ✅ | 需要续火的朋友的用户名称， JSON 字符串数组，例如 ["暮邵落白"] （不会写 JSON 可以问 AI）。建议在抖音中给好友设置备注名并填备注名，好友改昵称也不会中断续火 |
+| `DOUYIN_ACCOUNTS` | ✅ | 抖音账号 JSON 数组，每个账号包含 `name`、`cookie`、`targetNames`、`messageTemplate` |
 | `YIYAN_INCLUDE_SOURCE` | ❌ | 是否携带一言出处，默认开启；设置为 `false` 时只发送正文 |
 | `SPARK_MESSAGE_TEMPLATE` | ❌ | 自定义火花消息模板，见下方「✉️ 自定义消息模板」 |
 | `MAIL_ADDRESS` | ❌ | 任务失败提醒的收件邮箱，同时作为邮件发件人地址 |
@@ -106,6 +105,64 @@ Settings -> Secrets and variables -> Actions -> New repository secret
 | `MAIL_PASSWORD` | ❌ | QQ 邮箱 SMTP 授权码 |
 
 配置 `MAIL_ADDRESS`、`MAIL_USERNAME` 和 `MAIL_PASSWORD` 后，续火失败会向 `MAIL_ADDRESS` 发送提醒邮件，并附带失败图片。
+
+`DOUYIN_ACCOUNTS` 可以直接粘贴下面这种多行 JSON。每个账号的 `cookie` 都要替换成 Cookie-Editor 导出的完整数组，不能只替换示例中的一个 Cookie。
+
+```json
+[
+  {
+    "name": "账号1",
+    "cookie": [
+      {
+        "domain": ".douyin.com",
+        "expirationDate": 1800175766.87008,
+        "hostOnly": false,
+        "httpOnly": false,
+        "name": "UIFID",
+        "path": "/",
+        "sameSite": "no_restriction",
+        "secure": true,
+        "session": false,
+        "storeId": null,
+        "value": "账号1的真实 Cookie 值"
+      }
+    ],
+    "targetNames": ["好友A", "好友B"],
+    "messageTemplate": "{{friend}}，今天也来续火啦\\n{{yiyan}}\\n——「{{from}}」"
+  },
+  {
+    "name": "账号2",
+    "cookie": [
+      {
+        "domain": ".douyin.com",
+        "expirationDate": 1800175766.87008,
+        "hostOnly": false,
+        "httpOnly": false,
+        "name": "UIFID",
+        "path": "/",
+        "sameSite": "no_restriction",
+        "secure": true,
+        "session": false,
+        "storeId": null,
+        "value": "账号2的真实 Cookie 值"
+      }
+    ],
+    "targetNames": ["好友C"],
+    "messageTemplate": "{{friend}}，{{account}} 今天来续火啦\\n{{date}} {{weekday}}"
+  }
+]
+```
+
+账号级 `messageTemplate` 未配置时，会使用全局 `SPARK_MESSAGE_TEMPLATE`；全局模板也未配置时使用默认一言格式。
+
+每个账号对象支持的字段：
+
+| 字段 | 必填 | 说明 |
+|:---|:---:|:---|
+| `name` | ✅ | 账号标识，用于日志、错误提示、失败截图和 `{{account}}` 占位符；不同账号不能重名 |
+| `cookie` | ✅ | Cookie-Editor 为这个账号导出的完整 JSON 数组 |
+| `targetNames` | ✅ | 这个账号需要发送消息的好友名称数组，建议使用抖音备注名 |
+| `messageTemplate` | ❌ | 账号独立模板；JSON 字符串中的换行写成 `\n`，未配置时继承全局模板 |
 
 #### 3️⃣ 手动运行一次
 
@@ -143,18 +200,38 @@ cp .env.example .env
 
 | 变量 | 必填 | 默认值 | 说明 |
 |:---|:---:|:---:|:---|
-| `DOUYIN_COOKIE` | ✅ | - | 抖音 Cookie JSON 字符串数组 |
-| `DOUYIN_TARGET_NAMES` | ✅ | - | 要发送消息的会话名称 JSON 字符串数组 |
+| `DOUYIN_ACCOUNTS` | ✅ | - | 抖音账号 JSON 数组，结构与上方 GitHub Secret 相同 |
 | `YIYAN_INCLUDE_SOURCE` | ❌ | `true` | 是否携带一言出处，设置为 `false` 时只发送正文 |
 | `SPARK_MESSAGE_TEMPLATE` | ❌ | - | 自定义火花消息模板，见下方「自定义消息模板」 |
 | `PLAYWRIGHT_BROWSER_PATH` | ❌ | - | 本机 Chrome / Chromium / Edge 可执行文件路径，不填则使用 Playwright 默认浏览器 |
 | `PLAYWRIGHT_HEADLESS` | ❌ | `true` | 是否使用无头模式 |
 | `AUTO_CLOSE` | ❌ | `true` | 发送完成后是否自动关闭浏览器 |
 
-`DOUYIN_TARGET_NAMES` 示例：
+本地 `.env` 示例：
 
 ```dotenv
-DOUYIN_TARGET_NAMES='["暮邵落白"]'
+DOUYIN_ACCOUNTS='[
+  {
+    "name": "账号1",
+    "cookie": [
+      {
+        "domain": ".douyin.com",
+        "expirationDate": 1800175766.87008,
+        "hostOnly": false,
+        "httpOnly": false,
+        "name": "UIFID",
+        "path": "/",
+        "sameSite": "no_restriction",
+        "secure": true,
+        "session": false,
+        "storeId": null,
+        "value": "替换成真实 Cookie 值"
+      }
+    ],
+    "targetNames": ["好友A", "好友B"],
+    "messageTemplate": "{{friend}}，今天也来续火啦\\n{{yiyan}}"
+  }
+]'
 ```
 
 > 💡 **建议填备注名而不是昵称**
@@ -163,11 +240,7 @@ DOUYIN_TARGET_NAMES='["暮邵落白"]'
 > 在抖音中给好友设置备注后，搜索框同样能按备注名搜到人，而备注是你自己设置的，
 > 好友再怎么改昵称都不受影响。设置方式：好友主页 → 右上角 `...` → 设置备注。
 
-`DOUYIN_COOKIE` 使用准备工作中导出的 Cookie JSON 数组：
-
-```dotenv
-DOUYIN_COOKIE='[{"domain":".douyin.com","expirationDate":1800175766.87008,"hostOnly":false,"httpOnly":false,"name":"UIFID","path":"/","sameSite":"no_restriction","secure":true,"session":false,"storeId":null,"value":"替换成真实 Cookie 值"}]'
-```
+旧版 `DOUYIN_COOKIE` 和 `DOUYIN_TARGET_NAMES` 仍然兼容。配置 `DOUYIN_ACCOUNTS` 后，新配置优先，旧变量会被忽略。
 
 #### 3️⃣ 启动项目
 
@@ -175,11 +248,11 @@ DOUYIN_COOKIE='[{"domain":".douyin.com","expirationDate":1800175766.87008,"hostO
 pnpm dev
 ```
 
-脚本会打开 `https://www.douyin.com/chat`，等待页面加载，定位配置中的会话名称，发送随机一言，并在发送后等待约 5 秒再退出。
+脚本会为每个账号创建独立浏览器上下文，依次打开 `https://www.douyin.com/chat`、发送消息并关闭上下文。某个账号失败后会保存账号专属截图并继续执行其余账号，全部执行结束后统一报告失败。
 
 ## ✉️ 自定义消息模板
 
-配置 `SPARK_MESSAGE_TEMPLATE` 可自定义消息内容：
+配置 `SPARK_MESSAGE_TEMPLATE` 可定义所有账号共用的默认消息内容；账号对象中的 `messageTemplate` 可以覆盖它：
 
 ```dotenv
 SPARK_MESSAGE_TEMPLATE={{friend}}，今天的火花到账啦🔥\n{{yiyan}}\n——「{{from}}」\n{{date}} {{weekday}}
@@ -189,6 +262,7 @@ SPARK_MESSAGE_TEMPLATE={{friend}}，今天的火花到账啦🔥\n{{yiyan}}\n—
 
 | 占位符 | 说明 |
 |:---|:---|
+| `{{account}}` | 当前账号的配置名称 |
 | `{{friend}}` | 好友名 |
 | `{{yiyan}}` | 一言正文 |
 | `{{from}}` | 一言出处 |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: true

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config'
-import { chromium, type Cookie, type Page } from 'playwright'
+import { chromium, type Browser, type Cookie, type Page } from 'playwright'
 import { mkdir, readFile } from 'node:fs/promises'
 import { createInterface } from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
@@ -14,14 +14,16 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.locale('zh-cn')
 
+const DOUYIN_ACCOUNTS_KEY = 'DOUYIN_ACCOUNTS'
 const DOUYIN_COOKIE_KEY = 'DOUYIN_COOKIE'
 const DOUYIN_TARGET_NAMES_KEY = 'DOUYIN_TARGET_NAMES'
 const YIYAN_INCLUDE_SOURCE_KEY = 'YIYAN_INCLUDE_SOURCE'
 const SPARK_MESSAGE_TEMPLATE_KEY = 'SPARK_MESSAGE_TEMPLATE'
-const FAILURE_SCREENSHOT_PATH = 'artifacts/failure-screenshot.png'
+const FAILURE_SCREENSHOT_DIRECTORY = 'artifacts'
 
 const MESSAGE_TEMPLATE_PLACEHOLDER_PATTERN = /\{\{\s*([a-zA-Z]+)\s*\}\}/g
 const MESSAGE_TEMPLATE_PLACEHOLDERS = [
+  'account',
   'friend',
   'yiyan',
   'from',
@@ -32,6 +34,13 @@ const MESSAGE_TEMPLATE_PLACEHOLDERS = [
 
 type MessageTemplatePlaceholder = (typeof MESSAGE_TEMPLATE_PLACEHOLDERS)[number]
 
+interface DouyinAccount {
+  name: string
+  cookies: Cookie[]
+  targetNames: string[]
+  messageTemplate: string | undefined
+}
+
 /**
  * 启动本机 Chrome 浏览器并携带 Cookie 访问抖音聊天页。
  */
@@ -40,22 +49,63 @@ async function main(): Promise<void> {
   const headless = resolveHeadless()
   const autoClose = resolveAutoClose()
   const includeYiyanSource = resolveYiyanIncludeSource()
-  const messageTemplate = resolveSparkMessageTemplate()
-  const douyinCookies = resolveDouyinCookies()
-  const targetNames = resolveDouyinTargetNames()
+  const globalMessageTemplate = resolveSparkMessageTemplate()
+  const accounts = resolveDouyinAccounts(globalMessageTemplate)
   const yiyans = await resolveYiyans()
-  // 模板未用到一言时无需抽取；默认格式始终需要。
-  const needsYiyan =
-    messageTemplate === undefined || /\{\{\s*(yiyan|from)\s*\}\}/.test(messageTemplate)
   const browser = await chromium.launch({
     headless,
     ...(browserPath ? { executablePath: browserPath } : {}),
   })
+  const failures: Error[] = []
+
+  try {
+    for (const account of accounts) {
+      try {
+        await runDouyinAccount(browser, account, yiyans, includeYiyanSource, autoClose)
+      } catch (error) {
+        const accountError = toError(error)
+        failures.push(
+          new Error(`[${account.name}] ${accountError.message}`, { cause: accountError }),
+        )
+        console.error(`账号执行失败：${account.name}`, accountError)
+      }
+    }
+
+    if (!autoClose) {
+      const readline = createInterface({
+        input,
+        output,
+      })
+
+      await readline.question('所有账号已执行完成，按回车键关闭浏览器...')
+      readline.close()
+    }
+
+    if (failures.length > 0) {
+      throw new AggregateError(failures, `${failures.length} 个抖音账号执行失败`)
+    }
+  } finally {
+    // 无论任务是否失败，都关闭浏览器以释放 Playwright 持有的进程句柄。
+    await browser.close()
+  }
+}
+
+/**
+ * 使用独立浏览器上下文执行一个抖音账号，避免不同账号的 Cookie 相互污染。
+ */
+async function runDouyinAccount(
+  browser: Browser,
+  account: DouyinAccount,
+  yiyans: Yiyan[],
+  includeYiyanSource: boolean,
+  autoClose: boolean,
+): Promise<void> {
+  const context = await browser.newContext()
   let page: Page | undefined
 
   try {
-    const context = await browser.newContext()
-    await context.addCookies(douyinCookies)
+    console.log(`开始执行账号：${account.name}`)
+    await context.addCookies(account.cookies)
 
     page = await context.newPage()
     await page.goto('https://www.douyin.com/chat', {
@@ -65,35 +115,42 @@ async function main(): Promise<void> {
     await page.waitForTimeout(10000)
 
     const searchInput = page.locator('input.semi-input[placeholder="搜索"]').first()
-    await searchInput.waitFor({ state: 'visible', timeout: 10000 })
+    const searchVisible = await searchInput
+      .waitFor({ state: 'visible', timeout: 10000 })
+      .then(() => true)
+      .catch(() => false)
+
+    if (!searchVisible) {
+      throw new Error('聊天页搜索框未出现，Cookie 可能已经失效')
+    }
 
     // 记录未命中的会话，等其余好友都发完再统一报错，避免一个人改名连累当天所有人。
     const missingNames: string[] = []
+    const needsYiyan =
+      account.messageTemplate === undefined ||
+      /\{\{\s*(yiyan|from)\s*\}\}/.test(account.messageTemplate)
 
-    for (const targetName of targetNames) {
-      const name = String(targetName).trim()
-      if (!name) continue
-
-      console.log(`开始搜索会话：${name}`)
+    for (const targetName of account.targetNames) {
+      console.log(`[${account.name}] 开始搜索会话：${targetName}`)
       await searchInput.fill('')
-      await searchInput.fill(name)
+      await searchInput.fill(targetName)
       await page.waitForTimeout(1000)
 
       const searchResult = page
         .locator('.SearchPanelitembox')
         .filter({
-          has: page.getByText(name, { exact: true }),
+          has: page.getByText(targetName, { exact: true }),
         })
         .first()
 
       if (!(await searchResult.isVisible({ timeout: 5000 }).catch(() => false))) {
-        console.log(`找不到搜索结果，已跳过：${name}`)
-        missingNames.push(name)
+        console.log(`[${account.name}] 找不到搜索结果，已跳过：${targetName}`)
+        missingNames.push(targetName)
         continue
       }
 
       await searchResult.getByText(/^(发消息|发私信)$/).click({ timeout: 5000 })
-      console.log(`已打开私信：${name}`)
+      console.log(`[${account.name}] 已打开私信：${targetName}`)
 
       const editorInput = page
         .locator(
@@ -105,10 +162,11 @@ async function main(): Promise<void> {
 
       let message: string
 
-      if (messageTemplate !== undefined) {
+      if (account.messageTemplate !== undefined) {
         message = renderMessageTemplate(
-          messageTemplate,
-          name,
+          account.messageTemplate,
+          account.name,
+          targetName,
           needsYiyan ? pickRandomYiyan(yiyans) : undefined,
         )
       } else {
@@ -118,57 +176,61 @@ async function main(): Promise<void> {
 
       await page.keyboard.insertText(message)
       await page.keyboard.press('Enter')
-      console.log(`已发送消息：${name}`)
+      console.log(`[${account.name}] 已发送消息：${targetName}`)
       await page.waitForTimeout(1000)
     }
 
     await page.waitForTimeout(5000)
 
-    if (!autoClose) {
-      const readline = createInterface({
-        input,
-        output,
-      })
-
-      await readline.question('Chrome 已打开抖音聊天页，按回车键关闭浏览器...')
-      readline.close()
-    }
-
-    // 静默跳过会让任务以成功状态结束，失败告警便永远不会触发，因此这里必须抛错。
     if (missingNames.length > 0) {
       throw new Error(
         `以下会话未找到，火花可能已经中断：${missingNames.join('、')}。` +
           `好友改昵称是最常见的原因，建议在抖音中为好友设置备注名，` +
-          `并把备注名填入 ${DOUYIN_TARGET_NAMES_KEY}，这样好友再改昵称也不会影响续火。`,
+          `并把备注名填入账号的 targetNames，这样好友再改昵称也不会影响续火。`,
       )
     }
+
+    console.log(`账号执行完成：${account.name}`)
   } catch (error) {
-    await captureFailureScreenshot(page)
+    await captureFailureScreenshot(page, account.name)
     throw error
   } finally {
-    // 无论任务是否失败，都关闭浏览器以释放 Playwright 持有的进程句柄。
-    await browser.close()
+    if (autoClose) {
+      await context.close()
+    }
   }
 }
 
 /**
  * 在页面仍可访问时保存失败现场，且不让截图错误覆盖原始任务异常。
  */
-async function captureFailureScreenshot(page: Page | undefined): Promise<void> {
+async function captureFailureScreenshot(
+  page: Page | undefined,
+  accountName: string,
+): Promise<void> {
   if (!page || page.isClosed()) {
     return
   }
 
   try {
-    await mkdir('artifacts', { recursive: true })
+    await mkdir(FAILURE_SCREENSHOT_DIRECTORY, { recursive: true })
+    const screenshotPath = `${FAILURE_SCREENSHOT_DIRECTORY}/failure-screenshot-${toSafeFileName(accountName)}.png`
     await page.screenshot({
-      path: FAILURE_SCREENSHOT_PATH,
+      path: screenshotPath,
       fullPage: true,
     })
-    console.log(`已保存失败截图：${FAILURE_SCREENSHOT_PATH}`)
+    console.log(`已保存失败截图：${screenshotPath}`)
   } catch (error) {
     console.error('保存失败截图失败:', error)
   }
+}
+
+function toSafeFileName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9\u4e00-\u9fff_-]+/g, '-').replace(/^-+|-+$/g, '') || 'account'
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
 }
 
 /**
@@ -253,6 +315,13 @@ function resolveSparkMessageTemplate(): string | undefined {
     return undefined
   }
 
+  return normalizeMessageTemplate(template, SPARK_MESSAGE_TEMPLATE_KEY)
+}
+
+/**
+ * 校验并标准化消息模板。
+ */
+function normalizeMessageTemplate(template: string, sourceName: string): string {
   // 启动时就校验占位符，避免把写错的 {{xxx}} 原样发给好友。
   const unknownPlaceholders = [
     ...new Set(
@@ -266,7 +335,7 @@ function resolveSparkMessageTemplate(): string | undefined {
 
   if (unknownPlaceholders.length > 0) {
     throw new Error(
-      `${SPARK_MESSAGE_TEMPLATE_KEY} 中存在未识别的占位符：${unknownPlaceholders
+      `${sourceName} 中存在未识别的占位符：${unknownPlaceholders
         .map((name) => `{{${name}}}`)
         .join(
           '、',
@@ -281,10 +350,16 @@ function resolveSparkMessageTemplate(): string | undefined {
 /**
  * 将消息模板渲染为实际发送的文本。
  */
-function renderMessageTemplate(template: string, friend: string, yiyan: Yiyan | undefined): string {
+function renderMessageTemplate(
+  template: string,
+  account: string,
+  friend: string,
+  yiyan: Yiyan | undefined,
+): string {
   // 定时任务跑在 UTC 时区的 runner 上，日期占位符统一按上海时区计算。
   const now = dayjs().tz('Asia/Shanghai')
   const placeholderValues: Record<MessageTemplatePlaceholder, string> = {
+    account,
     friend,
     yiyan: yiyan?.hitokoto ?? '',
     from: yiyan?.from ?? '',
@@ -299,28 +374,102 @@ function renderMessageTemplate(template: string, friend: string, yiyan: Yiyan | 
 }
 
 /**
- * 解析抖音访问需要携带的 Cookie。
+ * 解析多账号配置。未配置新变量时，回退到旧的单账号变量。
  */
-function resolveDouyinCookies(): Cookie[] {
-  const douyinCookieText = process.env[DOUYIN_COOKIE_KEY]?.trim()
+function resolveDouyinAccounts(globalMessageTemplate: string | undefined): DouyinAccount[] {
+  const accountsText = process.env[DOUYIN_ACCOUNTS_KEY]?.trim()
 
-  if (!douyinCookieText) {
-    throw new Error(`请设置环境变量 ${DOUYIN_COOKIE_KEY}，或在 .env 中配置 ${DOUYIN_COOKIE_KEY}`)
+  if (!accountsText) {
+    return [
+      {
+        name: '默认账号',
+        cookies: resolveLegacyDouyinCookies(),
+        targetNames: resolveLegacyDouyinTargetNames(),
+        messageTemplate: globalMessageTemplate,
+      },
+    ]
   }
 
-  const douyinCookies = JSON.parse(douyinCookieText) as DouyinCookie[]
+  const accountsValue = parseJson(accountsText, DOUYIN_ACCOUNTS_KEY)
 
-  if (!Array.isArray(douyinCookies)) {
-    throw new Error(`${DOUYIN_COOKIE_KEY} 必须是 Cookie 数组 JSON 字符串`)
+  if (!Array.isArray(accountsValue) || accountsValue.length === 0) {
+    throw new Error(`${DOUYIN_ACCOUNTS_KEY} 必须是非空账号数组 JSON`)
   }
 
-  return douyinCookies.map(toPlaywrightCookie)
+  const accountNames = new Set<string>()
+
+  return accountsValue.map((value, index) => {
+    const sourceName = `${DOUYIN_ACCOUNTS_KEY}[${index}]`
+
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      throw new Error(`${sourceName} 必须是账号对象`)
+    }
+
+    const accountValue = value as Record<string, unknown>
+    const name = resolveAccountName(accountValue.name, sourceName)
+
+    if (accountNames.has(name)) {
+      throw new Error(`${DOUYIN_ACCOUNTS_KEY} 中存在重复账号名称：${name}`)
+    }
+    accountNames.add(name)
+
+    return {
+      name,
+      cookies: resolveCookieArray(accountValue.cookie, `${sourceName}.cookie`),
+      targetNames: resolveTargetNameArray(accountValue.targetNames, `${sourceName}.targetNames`),
+      messageTemplate: resolveAccountMessageTemplate(
+        accountValue.messageTemplate,
+        `${sourceName}.messageTemplate`,
+        globalMessageTemplate,
+      ),
+    }
+  })
+}
+
+function resolveAccountName(value: unknown, sourceName: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${sourceName}.name 必须是非空字符串`)
+  }
+
+  return value.trim()
+}
+
+function resolveAccountMessageTemplate(
+  value: unknown,
+  sourceName: string,
+  globalMessageTemplate: string | undefined,
+): string | undefined {
+  if (value === undefined || value === null) {
+    return globalMessageTemplate
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`${sourceName} 必须是字符串`)
+  }
+
+  const template = value.trim()
+  return template ? normalizeMessageTemplate(template, sourceName) : globalMessageTemplate
 }
 
 /**
- * 解析需要发送消息的抖音会话名称。
+ * 解析旧版单账号 Cookie 配置。
  */
-function resolveDouyinTargetNames(): string[] {
+function resolveLegacyDouyinCookies(): Cookie[] {
+  const douyinCookieText = process.env[DOUYIN_COOKIE_KEY]?.trim()
+
+  if (!douyinCookieText) {
+    throw new Error(
+      `请设置 ${DOUYIN_ACCOUNTS_KEY}，或继续使用旧版 ${DOUYIN_COOKIE_KEY} 和 ${DOUYIN_TARGET_NAMES_KEY}`,
+    )
+  }
+
+  return resolveCookieArray(parseJson(douyinCookieText, DOUYIN_COOKIE_KEY), DOUYIN_COOKIE_KEY)
+}
+
+/**
+ * 解析旧版单账号会话名称配置。
+ */
+function resolveLegacyDouyinTargetNames(): string[] {
   const targetNamesText = process.env[DOUYIN_TARGET_NAMES_KEY]?.trim()
 
   if (!targetNamesText) {
@@ -329,17 +478,40 @@ function resolveDouyinTargetNames(): string[] {
     )
   }
 
-  const targetNames = JSON.parse(targetNamesText) as string[]
+  return resolveTargetNameArray(
+    parseJson(targetNamesText, DOUYIN_TARGET_NAMES_KEY),
+    DOUYIN_TARGET_NAMES_KEY,
+  )
+}
+
+function resolveCookieArray(value: unknown, sourceName: string): Cookie[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${sourceName} 必须是非空 Cookie 数组`)
+  }
+
+  return (value as DouyinCookie[]).map(toPlaywrightCookie)
+}
+
+function resolveTargetNameArray(value: unknown, sourceName: string): string[] {
+  const targetNames = value as unknown[]
 
   if (
     !Array.isArray(targetNames) ||
     targetNames.length === 0 ||
     targetNames.some((targetName) => typeof targetName !== 'string' || !targetName.trim())
   ) {
-    throw new Error(`${DOUYIN_TARGET_NAMES_KEY} 必须是非空字符串数组 JSON`)
+    throw new Error(`${sourceName} 必须是非空字符串数组`)
   }
 
-  return targetNames.map((targetName) => targetName.trim())
+  return targetNames.map((targetName) => (targetName as string).trim())
+}
+
+function parseJson(value: string, sourceName: string): unknown {
+  try {
+    return JSON.parse(value) as unknown
+  } catch (error) {
+    throw new Error(`${sourceName} 不是有效的 JSON`, { cause: error })
+  }
 }
 
 /**


### PR DESCRIPTION
更新内容：

- 新增 DOUYIN_ACCOUNTS 多账号 JSON 配置，每个账号独立设置 Cookie、好友和消息模板。

- 每个账号使用独立浏览器上下文，单个账号失败后继续执行其他账号，并保存账号专属失败截图。

- 新增账号级 messageTemplate 与 {{account}} 占位符，同时保留旧版单账号变量兼容。

- 更新 GitHub Actions、.env.example 和 README，补充完整中文配置说明。
